### PR TITLE
Fix support for Python template syntax

### DIFF
--- a/docs/templates.md
+++ b/docs/templates.md
@@ -92,6 +92,8 @@ prompt: >
 ```
 The `prompt: >` causes the following indented text to be treated as a single string, with newlines collapsed to spaces. Use `prompt: |` to preserve newlines.
 
+Strings in `prompt` and `system` use the Python `string.Template` [syntax](https://docs.python.org/3/library/string.html#template-strings). This means you can escape dollar signs by doubling them, or use curly braces to put placeholders inside words.
+
 Running that with `llm -t steampunk` against GPT-4 (via [strip-tags](https://github.com/simonw/strip-tags) to remove HTML tags from the input and minify whitespace):
 ```bash
 curl -s 'https://til.simonwillison.net/macos/imovie-slides-and-audio' | \

--- a/llm/templates.py
+++ b/llm/templates.py
@@ -41,17 +41,10 @@ class Template(BaseModel):
             return text
         # Confirm all variables in text are provided
         string_template = string.Template(text)
-        vars = cls.extract_vars(string_template)
+        vars = string_template.get_identifiers()
         missing = [p for p in vars if p not in params]
         if missing:
             raise cls.MissingVariables(
                 "Missing variables: {}".format(", ".join(missing))
             )
         return string_template.substitute(**params)
-
-    @staticmethod
-    def extract_vars(string_template: string.Template) -> List[str]:
-        return [
-            match.group("named")
-            for match in string_template.pattern.finditer(string_template.template)
-        ]

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -11,6 +11,7 @@ import yaml
 @pytest.mark.parametrize(
     "prompt,system,defaults,params,expected_prompt,expected_system,expected_error",
     (
+        ("$$test", None, None, {}, "$test", None, None),
         ("S: $input", None, None, {}, "S: input", None, None),
         ("S: $input", "system", None, {}, "S: input", "system", None),
         ("No vars", None, None, {}, "No vars", None, None),


### PR DESCRIPTION
All dollar signs in template prompt or system are interpreted as placeholders. The documentation for string.Template says that doubling a dollar sign should escape it.

Due to the custom implementation of `Template.extract_vars`, this did not work, as it extracted a double dollar sign as an identifier with an empty `named` group. By using `string.Template.get_identifiers()`, this now works. Additionally, this automatically adds support for parenthesized identifiers as well. 
